### PR TITLE
fix: remove ANSI escape codes from browser validation output

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [
-      "pnpm turbo lint",
-      "pnpm turbo typecheck"
+      "sh -c 'pnpm turbo run lint'",
+      "sh -c 'pnpm turbo run check-types'"
     ]
   },
   "dependencies": {

--- a/packages/nviron/src/utils/ansi-colors.ts
+++ b/packages/nviron/src/utils/ansi-colors.ts
@@ -1,5 +1,7 @@
+import { isBrowser } from "./detect-env";
+
 // ANSI color codes
-export const ansi = {
+export const ANSI_COLOR_CODES = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
@@ -28,32 +30,39 @@ export const ansi = {
   bgGray: "\x1b[100m",
 };
 
-// Helper functions for color-safe wrapping
+const wrapColor = (code: string) => {
+  return (msg: string) => {
+    if (isBrowser) return msg;
+    return `${code}${msg}${ANSI_COLOR_CODES.reset}`;
+  };
+};
+
+// Object mapping for color-safe wrapping
 export const paint = {
   // Foreground colors
-  black: (msg: string) => `${ansi.black}${msg}${ansi.reset}`,
-  red: (msg: string) => `${ansi.red}${msg}${ansi.reset}`,
-  green: (msg: string) => `${ansi.green}${msg}${ansi.reset}`,
-  yellow: (msg: string) => `${ansi.yellow}${msg}${ansi.reset}`,
-  blue: (msg: string) => `${ansi.blue}${msg}${ansi.reset}`,
-  magenta: (msg: string) => `${ansi.magenta}${msg}${ansi.reset}`,
-  cyan: (msg: string) => `${ansi.cyan}${msg}${ansi.reset}`,
-  white: (msg: string) => `${ansi.white}${msg}${ansi.reset}`,
-  gray: (msg: string) => `${ansi.gray}${msg}${ansi.reset}`,
+  black: wrapColor(ANSI_COLOR_CODES.black),
+  red: wrapColor(ANSI_COLOR_CODES.red),
+  green: wrapColor(ANSI_COLOR_CODES.green),
+  yellow: wrapColor(ANSI_COLOR_CODES.yellow),
+  blue: wrapColor(ANSI_COLOR_CODES.blue),
+  magenta: wrapColor(ANSI_COLOR_CODES.magenta),
+  cyan: wrapColor(ANSI_COLOR_CODES.cyan),
+  white: wrapColor(ANSI_COLOR_CODES.white),
+  gray: wrapColor(ANSI_COLOR_CODES.gray),
 
   // Background colors
-  bgBlack: (msg: string) => `${ansi.bgBlack}${msg}${ansi.reset}`,
-  bgRed: (msg: string) => `${ansi.bgRed}${msg}${ansi.reset}`,
-  bgGreen: (msg: string) => `${ansi.bgGreen}${msg}${ansi.reset}`,
-  bgYellow: (msg: string) => `${ansi.bgYellow}${msg}${ansi.reset}`,
-  bgBlue: (msg: string) => `${ansi.bgBlue}${msg}${ansi.reset}`,
-  bgMagenta: (msg: string) => `${ansi.bgMagenta}${msg}${ansi.reset}`,
-  bgCyan: (msg: string) => `${ansi.bgCyan}${msg}${ansi.reset}`,
-  bgWhite: (msg: string) => `${ansi.bgWhite}${msg}${ansi.reset}`,
-  bgGray: (msg: string) => `${ansi.bgGray}${msg}${ansi.reset}`,
+  bgBlack: wrapColor(ANSI_COLOR_CODES.bgBlack),
+  bgRed: wrapColor(ANSI_COLOR_CODES.bgRed),
+  bgGreen: wrapColor(ANSI_COLOR_CODES.bgGreen),
+  bgYellow: wrapColor(ANSI_COLOR_CODES.bgYellow),
+  bgBlue: wrapColor(ANSI_COLOR_CODES.bgBlue),
+  bgMagenta: wrapColor(ANSI_COLOR_CODES.bgMagenta),
+  bgCyan: wrapColor(ANSI_COLOR_CODES.bgCyan),
+  bgWhite: wrapColor(ANSI_COLOR_CODES.bgWhite),
+  bgGray: wrapColor(ANSI_COLOR_CODES.bgGray),
 
   // Styles
-  bold: (msg: string) => `${ansi.bold}${msg}${ansi.reset}`,
-  dim: (msg: string) => `${ansi.dim}${msg}${ansi.reset}`,
-  italic: (msg: string) => `${ansi.italic}${msg}${ansi.reset}`,
+  bold: wrapColor(ANSI_COLOR_CODES.bold),
+  dim: wrapColor(ANSI_COLOR_CODES.dim),
+  italic: wrapColor(ANSI_COLOR_CODES.italic),
 };

--- a/packages/nviron/src/utils/detect-env.ts
+++ b/packages/nviron/src/utils/detect-env.ts
@@ -1,6 +1,10 @@
-export const isNode = typeof process !== "undefined" && !!process.env;
+export const isBrowser =
+  typeof window !== "undefined" && typeof document !== "undefined";
+
+export const isNode =
+  typeof process !== "undefined" && !!process.versions?.node && !isBrowser;
 
 export function detectEnvSource() {
   if (isNode) return "node";
-  return "unknown";
+  return "browser";
 }

--- a/packages/nviron/tests/index.test.ts
+++ b/packages/nviron/tests/index.test.ts
@@ -174,4 +174,35 @@ describe("Environment Utilities", () => {
       });
     });
   });
+
+  describe("ansi color output", () => {
+    it("should disable ANSI colors in browser environments", async () => {
+      const browserGlobals = globalThis as unknown as Record<string, unknown>;
+      const previousWindow = browserGlobals.window;
+      const previousDocument = browserGlobals.document;
+
+      vi.resetModules();
+      browserGlobals.window = {};
+      browserGlobals.document = {};
+
+      try {
+        const { paint } = await import("../src/utils/ansi-colors");
+        expect(paint.red("validation failed")).toBe("validation failed");
+      } finally {
+        if (previousWindow === undefined) {
+          delete browserGlobals.window;
+        } else {
+          browserGlobals.window = previousWindow;
+        }
+
+        if (previousDocument === undefined) {
+          delete browserGlobals.document;
+        } else {
+          browserGlobals.document = previousDocument;
+        }
+
+        vi.resetModules();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- detect browser runtimes explicitly in env detection utilities and avoid treating browser contexts as Node
- disable ANSI wrapping in `paint` helpers when running in the browser so validation logs stay readable
- add a regression test that simulates browser globals and verifies color helpers return plain text

## Verification
- pnpm format --check
- pnpm lint
- pnpm check-types
- pnpm build
- pnpm --filter nviron test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ANSI color codes are now properly disabled when running in browser environments.

* **Chores**
  * Updated lint-staged configuration with improved command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->