### PR TITLE
fix(runtime): throw validation errors instead of exiting process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project generally follows [Semantic Versioning](https://semver.org/).
 
+## [2.1.10] - 2026-03-23
+
+### Fixed
+
+- Replaced `process.exit(1)` with a thrown validation error so invalid env config does not terminate Next.js and other Node.js server processes.
+
 ## [2.1.9] - 2026-03-21
 
 ### Changed
@@ -134,6 +140,7 @@ and this project generally follows [Semantic Versioning](https://semver.org/).
 - TypeScript project setup.
 - First `env` utility implementation.
 
+[2.1.10]: https://github.com/ubeyidah/nviron/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/ubeyidah/nviron/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/ubeyidah/nviron/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/ubeyidah/nviron/compare/v2.1.6...v2.1.7

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -355,7 +355,7 @@ z.number().refine((val) => val % 2 === 0, {
 
 ## Error Handling
 
-When validation fails, nviron formats errors in a user-friendly way and exits the process.
+When validation fails, nviron formats errors in a user-friendly way and then throws an error.
 
 ### Error Output Format
 
@@ -391,13 +391,13 @@ const env = defineEnv({
 });
 ```
 
-### Exit Behavior
+### Runtime Behavior
 
-By default, nviron exits the process when validation fails:
+By default, nviron throws when validation fails:
 
-- Exit code: `1`
-- Prevents application from running with invalid configuration
-- Displays colored error messages in the console
+- Throws an `Error` after printing formatted validation issues
+- Lets frameworks and runtimes handle failure safely (for example Next.js error boundaries)
+- Prevents silent startup with invalid configuration
 
 <Callout type="warn">
   **Production Behavior:** In production environments, ensure all environment

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -220,7 +220,7 @@ const env = defineEnv({
 
 ### What happens when validation fails?
 
-Nviron displays a clear error message and exits the process:
+Nviron displays a clear error message, then throws an error:
 
 ```bash
 ❌ Environment Variable Missing or Invalid

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -254,11 +254,11 @@ const env = defineEnv({
 });
 ```
 
-### How do I prevent the process from exiting on error?
+### How do I handle validation errors?
 
-Currently, nviron exits on validation failure by design to prevent running with invalid configuration. This is a safety feature.
+When validation fails, nviron throws an error by design to prevent running with invalid configuration. This is a safety feature.
 
-If you need different behavior, you can catch the error:
+You can catch the thrown error to handle it your way:
 
 ```typescript
 try {

--- a/docs/content/docs/installation/nextjs.mdx
+++ b/docs/content/docs/installation/nextjs.mdx
@@ -44,4 +44,6 @@ const nextConfig = {};
 export default nextConfig;
 ```
 
+When validation fails, nviron logs the issues and throws an error instead of exiting the Node.js process, which is safer for server runtimes.
+
 </Callout>

--- a/packages/nviron/package.json
+++ b/packages/nviron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nviron",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "",
   "main": "./src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/nviron/src/core/validator.ts
+++ b/packages/nviron/src/core/validator.ts
@@ -3,7 +3,6 @@ import { EnvSchema } from "../types/env-schema";
 import { Logger } from "../utils/logger";
 import { EnvConfig, EnvData } from "../types";
 import { normalizeEnv } from "../utils/utils";
-import { isNode } from "./../utils/detect-env";
 
 export const validateEnv = <T extends EnvSchema>(
   schema: T,
@@ -29,13 +28,9 @@ export const validateEnv = <T extends EnvSchema>(
 
     logger.tip();
 
-    if (isNode) {
-      process.exit(1);
-    } else {
-      throw new Error(
-        "Nviron: validation failed missing or invalid variable(s) in your .env. Check the details above.",
-      );
-    }
+    throw new Error(
+      "Nviron: validation failed missing or invalid variable(s) in your .env. Check the details above.",
+    );
   }
 
   return parsed.data;

--- a/packages/nviron/tests/index.test.ts
+++ b/packages/nviron/tests/index.test.ts
@@ -98,7 +98,7 @@ describe("Environment Utilities", () => {
       });
     });
 
-    it("should exit process on invalid env", () => {
+    it("should throw on invalid env", () => {
       const env = {
         PORT: "not-a-number",
       };
@@ -106,12 +106,9 @@ describe("Environment Utilities", () => {
         PORT: z.coerce.number(),
       };
 
-      const exitMock = vi.spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("process.exit called");
-      });
-
-      expect(() => validateEnv(schema, env, {})).toThrow("process.exit called");
-      expect(exitMock).toHaveBeenCalledWith(1);
+      expect(() => validateEnv(schema, env, {})).toThrow(
+        "Nviron: validation failed missing or invalid variable(s) in your .env. Check the details above.",
+      );
     });
 
     it("should display original and normalized keys in error messages for prefixed variables", () => {
@@ -122,15 +119,11 @@ describe("Environment Utilities", () => {
         PORT: z.coerce.number(),
       };
 
-      const exitMock = vi.spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("process.exit called");
-      });
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       expect(() => validateEnv(schema, env, { prefix: "VITE_" })).toThrow(
-        "process.exit called",
+        "Nviron: validation failed missing or invalid variable(s) in your .env. Check the details above.",
       );
-      expect(exitMock).toHaveBeenCalledWith(1);
       expect(stripAnsi(consoleSpy.mock.calls[2][0])).toContain(
         "1. VITE_PORT (as PORT) → Invalid input: expected number, received NaN",
       );

--- a/packages/nviron/tests/index.test.ts
+++ b/packages/nviron/tests/index.test.ts
@@ -124,9 +124,16 @@ describe("Environment Utilities", () => {
       expect(() => validateEnv(schema, env, { prefix: "VITE_" })).toThrow(
         "Nviron: validation failed missing or invalid variable(s) in your .env. Check the details above.",
       );
-      expect(stripAnsi(consoleSpy.mock.calls[2][0])).toContain(
-        "1. VITE_PORT (as PORT) → Invalid input: expected number, received NaN",
+      const loggedLines = consoleSpy.mock.calls.map((call) =>
+        stripAnsi(String(call[0])),
       );
+      expect(
+        loggedLines.some((line) =>
+          line.includes(
+            "1. VITE_PORT (as PORT) → Invalid input: expected number, received NaN",
+          ),
+        ),
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace `process.exit(1)` in env validation with a thrown error after logging so Next.js/Node servers are not force-terminated on invalid config.
- Update nviron tests to assert throw-on-validation behavior and keep prefixed-key error output coverage.
- Update docs to describe throw behavior, and release as `nviron@2.1.10` with changelog entry.

## Why
- `process.exit(1)` in library runtime code can crash production servers (including Next.js) when env validation fails, causing full process termination instead of an application-handled failure path.

## Validation
- `pnpm --filter nviron test`
- `pnpm --filter nviron build`

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation failures now throw an error instead of terminating the Node.js process with exit code 1, allowing the surrounding runtime to handle failures.

* **Documentation**
  * Updated API reference, FAQ, and Next.js guidance to describe the new runtime error behavior and handling recommendations.

* **Chores**
  * Recorded release version 2.1.10 in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->